### PR TITLE
Integrations - Data Feed Sync

### DIFF
--- a/TAK-Portal_Streaming_DataFeed_Handoff.md
+++ b/TAK-Portal_Streaming_DataFeed_Handoff.md
@@ -1,0 +1,65 @@
+# Feature Handoff: Streaming Data Feed Provisioning via TAK Portal
+
+**Objective**: Extend the existing "Create Integration" workflow in TAK Portal to automatically construct a corresponding "Streaming Data Feed" inside the upstream TAK Server, while providing a decoupled architecture allowing retroactive configuration.
+
+## 1. Overview
+When an administrator creates a new Integration user, they frequently need a streaming data feed bound to that integration. This modification introduces an intermediate modal structure that captures streaming data feed metrics. It additionally grants administrators the choice to skip the prompt, decouple the creation process, and visually observe mapped Integrations directly in the portal dashboard via new Red/Green table toggles. 
+
+## 2. Modified Files
+- `views/integrations.ejs`
+- `routes/integrations.routes.js`
+- `services/users.service.js`
+
+---
+
+## 3. Frontend Implementation Details (`views/integrations.ejs`)
+
+### Modal Markup & Decoupled User Experience
+- The `createForm` logic intercepts the payload instead of immediately dispatching. 
+- A designated "Make Streaming Data Feed? [Yes/No]" dropdown governs the initial context. If `No`, the Integration pushes cleanly with a `skipDataFeed: true` boolean payload.
+- If `Yes`, a secondary modal (`dataFeedModalOverlay`) sliders over mimicking TAK Server's configuration options:
+  - `*Name` (auto-populated with the Integration's `Title`)
+  - `Tags` (Newline-separated block)
+  - `Protocol` (Dropdown)
+  - `Authentication Type` (Dropdown)
+  - `Port` (Integer)
+  - `Core Messaging Version` & Checkboxes for discrete mapping of `TLSv1, TLSv1.1, TLSv1.2, TLSv1.3`.
+  - `Multicast Group`, `Interface`, `Sync Cache Retention`, `Archive`, `Anonymous Group`, `Archive Only`, `Sync`, `Federated`.
+
+### Group Filtering & Dynamic Render States
+- The modal organically populates a dynamically scrolling checkbox list corresponding to `groupsCache` (Authentik Groups).
+- Visually checking the box belonging to the Group initialized in Step 1 minimizes redundant workflow steps.
+- **Table Visual Indicators**:
+   - The Integration Table renders `dataFeedName` via Red `<button>` bindings if unmapped (`No DF`) or Green bindings if active (`DF Enabled`).
+   - The Red button enables a retroactive "create" flow sending users to configuring a feed after the fact.
+   - The Green button implements a `GET` proxy proxy query rendering the data in purely read-only to show how it's structurally formatted on TAK Server explicitly.
+
+---
+
+## 4. Backend Implementation Details (`routes/integrations.routes.js` & `services/users.service.js`)
+
+### Storage Hooks & Authentik API Patching
+- `services/users.service.js` includes an exported `updateUserAttributes()` utility designed to `api.patch()` into `attributes: JSON.stringify({...})`. 
+- When an administrator provisions a Data Feed initially, the UI successfully constructs the object on TAK Server and then immediately saves the `tak_data_feed_name` onto the Authentik object metadata. This guarantees safe binding and prevents messy proxy queries based strictly on Titles.
+
+### Payload Deconstruction
+- `POST /api/integrations`: The body now parses `skipDataFeed` parsing logic to bypass cleanly, along with the `dataFeedName` logic on success.
+- `GET /api/integrations`: Correctly parses out `.attributes.tak_data_feed_name` distributing the UI boolean to power the Red/Green table.
+
+### Retroactive API Endpoints
+- **`GET /api/integrations/:username/datafeed`**: Proxies requests securely to `takClient.get("/api/datafeeds/{dataFeedName}")` resolving the TAK XML/JAXB model precisely.
+- **`POST /api/integrations/:username/datafeed`**: Decoupled initialization hook resolving the `takSvc.post` to reconstruct a newly generated feed out-of-band and bind it via `updateUserAttributes`.
+
+### Non-Fatal Data Feed Handling
+- Currently, the initial API flow implements a "Graceful Decay" error model.
+- If `/api/datafeeds` encounters a 4xx/5xx failure (e.g., misconfigured TLS version, or TAK Node syncing issues), it drops the failure reason into `dataFeedError`.
+- It *does not* kill or roll-back the overall `createIntegration` payload. Rather, it surfaces `dataFeedError` within the `res.json` body.
+
+---
+
+## 5. Aspects for Code Optimization & Developer Review
+If you decide to accept, tweak, or optimize these concepts, please consider the following contexts:
+
+1. **Transaction State / Rollbacks**: The current model assumes that an integration surviving without a data stream is better than failing abruptly. If you'd prefer strict transactional fidelity, you might consider invoking `takSshSvc.revoke...` or sweeping the Authentik hooks to kill the user immediately if the data feed HTTP POST fails.
+2. **TAK Node Clusters (CoreConfig)**: `POST /api/datafeeds` in clustered environments depends upon Ignite clustering propagation. The current flow waits for HTTP 200 sequentially. If your environments experience heavy node delays, injecting standard timeout/retry architectures here could be beneficial.
+3. **Internal `takSvc` Axios Context**: The payload is using `takSvc.buildTakAxios()`. Feel free to review its Base URL handling regarding `/Marti` context roots to ensure maximum compatibility with user configurations leveraging standalone endpoints versus proxies.

--- a/TAK-Portal_Streaming_DataFeed_Handoff.md
+++ b/TAK-Portal_Streaming_DataFeed_Handoff.md
@@ -60,6 +60,6 @@ When an administrator creates a new Integration user, they frequently need a str
 ## 5. Aspects for Code Optimization & Developer Review
 If you decide to accept, tweak, or optimize these concepts, please consider the following contexts:
 
-1. **Transaction State / Rollbacks**: The current model assumes that an integration surviving without a data stream is better than failing abruptly. If you'd prefer strict transactional fidelity, you might consider invoking `takSshSvc.revoke...` or sweeping the Authentik hooks to kill the user immediately if the data feed HTTP POST fails.
+1. **Transaction State / Deletions**: The deletion sequence (`DELETE /api/integrations/:userId`) automatically hooks into Authentik to pull the mapped `tak_data_feed_name`, securely querying `takSvc` to permanently cascade and delete the streaming data feed *prior* to wiping the Integration Account. This guarantees orphan profiles do not clutter the TAK Server schema. If creation endpoints drop...
 2. **TAK Node Clusters (CoreConfig)**: `POST /api/datafeeds` in clustered environments depends upon Ignite clustering propagation. The current flow waits for HTTP 200 sequentially. If your environments experience heavy node delays, injecting standard timeout/retry architectures here could be beneficial.
 3. **Internal `takSvc` Axios Context**: The payload is using `takSvc.buildTakAxios()`. Feel free to review its Base URL handling regarding `/Marti` context roots to ensure maximum compatibility with user configurations leveraging standalone endpoints versus proxies.

--- a/TAK-Portal_Streaming_DataFeed_Handoff.md
+++ b/TAK-Portal_Streaming_DataFeed_Handoff.md
@@ -32,7 +32,8 @@ When an administrator creates a new Integration user, they frequently need a str
 - **Table Visual Indicators**:
    - The Integration Table renders `dataFeedName` via Red `<button>` bindings if unmapped (`No DF`) or Green bindings if active (`DF Enabled`).
    - The Red button enables a retroactive "create" flow sending users to configuring a feed after the fact.
-   - The Green button implements a `GET` proxy proxy query rendering the data in purely read-only to show how it's structurally formatted on TAK Server explicitly.
+   - The Green button implements a `GET` proxy query rendering the data in purely read-only to show how it's structurally formatted on TAK Server explicitly.
+   - The Modal header is context-aware via Javascript hooks and smoothly transitions between `Create Streaming Data Feed` and `Data Feed Details` reflecting active provision vs inspection states.
 
 ---
 

--- a/TAK-Portal_Streaming_DataFeed_Handoff.md
+++ b/TAK-Portal_Streaming_DataFeed_Handoff.md
@@ -18,11 +18,11 @@ When an administrator creates a new Integration user, they frequently need a str
 - The `createForm` logic intercepts the payload instead of immediately dispatching. 
 - A designated "Make Streaming Data Feed? [Yes/No]" dropdown governs the initial context. If `No`, the Integration pushes cleanly with a `skipDataFeed: true` boolean payload.
 - If `Yes`, a secondary modal (`dataFeedModalOverlay`) sliders over mimicking TAK Server's configuration options:
-  - `*Name` (auto-populated with the Integration's `Title`)
+  - `Data Feed Name` (Disabled; strictly bound to the auto-generated Integration User Name e.g. `nodered-[type]-[name]` to prevent naming collisions)
   - `Tags` (Newline-separated block)
   - `Protocol` (Dropdown)
   - `Authentication Type` (Dropdown)
-  - `Port` (Integer)
+  - `Port` (Integer) - includes a reminder note to open firewall rules.
   - `Core Messaging Version` & Checkboxes for discrete mapping of `TLSv1, TLSv1.1, TLSv1.2, TLSv1.3`.
   - `Multicast Group`, `Interface`, `Sync Cache Retention`, `Archive`, `Anonymous Group`, `Archive Only`, `Sync`, `Federated`.
 
@@ -39,16 +39,16 @@ When an administrator creates a new Integration user, they frequently need a str
 ## 4. Backend Implementation Details (`routes/integrations.routes.js` & `services/users.service.js`)
 
 ### Storage Hooks & Authentik API Patching
-- `services/users.service.js` includes an exported `updateUserAttributes()` utility designed to `api.patch()` into `attributes: JSON.stringify({...})`. 
+- `services/users.service.js` includes an exported `updateUserAttributes()` utility designed to `api.patch()` into `attributes: {...}` (utilizing strictly raw JSON to prevent mapping rejection by Authentik). 
 - When an administrator provisions a Data Feed initially, the UI successfully constructs the object on TAK Server and then immediately saves the `tak_data_feed_name` onto the Authentik object metadata. This guarantees safe binding and prevents messy proxy queries based strictly on Titles.
 
 ### Payload Deconstruction
-- `POST /api/integrations`: The body now parses `skipDataFeed` parsing logic to bypass cleanly, along with the `dataFeedName` logic on success.
+- `POST /api/integrations`: The body now parses `skipDataFeed` logic to bypass cleanly. The API dynamically infers `dataFeedName` directly from the generated user payload output instead of trusting frontend nomenclature, providing strict 1:1 binding parity.
 - `GET /api/integrations`: Correctly parses out `.attributes.tak_data_feed_name` distributing the UI boolean to power the Red/Green table.
 
 ### Retroactive API Endpoints
 - **`GET /api/integrations/:username/datafeed`**: Proxies requests securely to `takClient.get("/api/datafeeds/{dataFeedName}")` resolving the TAK XML/JAXB model precisely.
-- **`POST /api/integrations/:username/datafeed`**: Decoupled initialization hook resolving the `takSvc.post` to reconstruct a newly generated feed out-of-band and bind it via `updateUserAttributes`.
+- **`POST /api/integrations/:username/datafeed`**: Decoupled initialization hook resolving the `takSvc.post` to reconstruct a newly generated feed out-of-band using the path `username`.
 
 ### Non-Fatal Data Feed Handling
 - Currently, the initial API flow implements a "Graceful Decay" error model.

--- a/routes/integrations.routes.js
+++ b/routes/integrations.routes.js
@@ -97,14 +97,16 @@ router.post("/", async (req, res) => {
 
     let dataFeedError = "";
     const isSkipDataFeed = String(skipDataFeed) === "true";
-    if (!isSkipDataFeed && dataFeedName && takSvc.isTakConfigured()) {
+    const finalDataFeedName = (result && result.user && result.user.username) || dataFeedName;
+
+    if (!isSkipDataFeed && finalDataFeedName && takSvc.isTakConfigured()) {
       try {
         const payloadTags = tags ? tags.split(/[\n,]+/).map(t => t.trim()).filter(Boolean) : [];
         const strippedGroups = Array.isArray(filterGroups) ? filterGroups.map(stripTakPrefix) : [];
         
         const dataFeedPayload = {
           type: "Streaming",
-          name: dataFeedName,
+          name: finalDataFeedName,
           protocol: protocol || "tls",
           auth: authType || "X_509",
           port: port ? parseInt(port, 10) : 8089,
@@ -127,7 +129,7 @@ router.post("/", async (req, res) => {
 
         try {
           if (result && result.user && result.user.pk) {
-            await users.updateUserAttributes(result.user.pk, { tak_data_feed_name: dataFeedName });
+            await users.updateUserAttributes(result.user.pk, { tak_data_feed_name: finalDataFeedName });
           }
         } catch (attrsErr) {
            console.warn("Failed to securely hook data feed name into Authentik attributes:", attrsErr);
@@ -358,11 +360,9 @@ router.post("/:username/datafeed", async (req, res) => {
       return res.status(400).json({ error: "Integration already has an associated Data Feed." });
     }
 
-    const { dataFeedName, protocol, authType, port, coreVersion, coreVersion2TlsVersions, multicastGroup, iface, syncCacheRetention, archive, anongroup, archiveOnly, sync, federated, tags, filterGroups } = req.body || {};
+    const { protocol, authType, port, coreVersion, coreVersion2TlsVersions, multicastGroup, iface, syncCacheRetention, archive, anongroup, archiveOnly, sync, federated, tags, filterGroups } = req.body || {};
 
-    if (!dataFeedName) {
-      return res.status(400).json({ error: "Data Feed Name is required." });
-    }
+    const dataFeedName = user.username;
 
     if (!takSvc.isTakConfigured()) {
       return res.status(503).json({ error: "TAK Server connection is not configured." });

--- a/routes/integrations.routes.js
+++ b/routes/integrations.routes.js
@@ -289,6 +289,17 @@ router.delete("/:userId", async (req, res) => {
     if (!username.startsWith("nodered-")) {
       return res.status(403).json({ error: "Not an integration user." });
     }
+
+    const dataFeedName = user.attributes?.tak_data_feed_name;
+    if (dataFeedName && takSvc.isTakConfigured()) {
+       try {
+           const takClient = takSvc.buildTakAxios();
+           await takClient.delete(`/api/datafeeds/${encodeURIComponent(dataFeedName)}`);
+       } catch (err) {
+           console.warn(`Failed to inherently delete associated data feed '${dataFeedName}' for user '${username}':`, err.message);
+       }
+    }
+
     await takSshSvc.revokeIntegrationCertViaSshScript(username);
     await users.deleteUser(userId, { ignoreLocks: true });
     const authUser = req.authentikUser || null;

--- a/routes/integrations.routes.js
+++ b/routes/integrations.routes.js
@@ -97,7 +97,10 @@ router.post("/", async (req, res) => {
 
     let dataFeedError = "";
     const isSkipDataFeed = String(skipDataFeed) === "true";
-    const finalDataFeedName = (result && result.user && result.user.username) || dataFeedName;
+    let finalDataFeedName = (result && result.user && result.user.username) || dataFeedName;
+    if (finalDataFeedName) {
+        finalDataFeedName = finalDataFeedName.replace(/-/g, "_");
+    }
 
     if (!isSkipDataFeed && finalDataFeedName && takSvc.isTakConfigured()) {
       try {
@@ -362,7 +365,7 @@ router.post("/:username/datafeed", async (req, res) => {
 
     const { protocol, authType, port, coreVersion, coreVersion2TlsVersions, multicastGroup, iface, syncCacheRetention, archive, anongroup, archiveOnly, sync, federated, tags, filterGroups } = req.body || {};
 
-    const dataFeedName = user.username;
+    const dataFeedName = user.username ? user.username.replace(/-/g, "_") : undefined;
 
     if (!takSvc.isTakConfigured()) {
       return res.status(503).json({ error: "TAK Server connection is not configured." });

--- a/routes/integrations.routes.js
+++ b/routes/integrations.routes.js
@@ -4,6 +4,7 @@ const users = require("../services/users.service");
 const groupsSvc = require("../services/groups.service");
 const auditSvc = require("../services/auditLog.service");
 const takSshSvc = require("../services/takSsh.service");
+const takSvc = require("../services/tak.service");
 const { toSafeApiError } = require("../services/apiErrorPayload.service");
 const archiver = require("archiver");
 
@@ -47,6 +48,7 @@ router.get("/", async (req, res) => {
         groups: groupPks,
         groupNames,
         certBundleReady: takSshSvc.hasStoredIntegrationCertFiles(u.username),
+        dataFeedName: u.attributes?.tak_data_feed_name || null,
       };
     });
 
@@ -63,7 +65,7 @@ router.get("/", async (req, res) => {
  */
 router.post("/", async (req, res) => {
   try {
-    const { type, title, groupId, state, county, agencySuffix } = req.body || {};
+    const { type, title, groupId, state, county, agencySuffix, skipDataFeed, dataFeedName, protocol, authType, port, coreVersion, coreVersion2TlsVersions, multicastGroup, iface, syncCacheRetention, archive, anongroup, archiveOnly, sync, federated, tags, filterGroups } = req.body || {};
     const authUser = req.authentikUser || null;
     const createdBy = authUser
       ? {
@@ -93,6 +95,48 @@ router.post("/", async (req, res) => {
       certError = certErr?.message || String(certErr);
     }
 
+    let dataFeedError = "";
+    const isSkipDataFeed = String(skipDataFeed) === "true";
+    if (!isSkipDataFeed && dataFeedName && takSvc.isTakConfigured()) {
+      try {
+        const payloadTags = tags ? tags.split(/[\n,]+/).map(t => t.trim()).filter(Boolean) : [];
+        const strippedGroups = Array.isArray(filterGroups) ? filterGroups.map(stripTakPrefix) : [];
+        
+        const dataFeedPayload = {
+          type: "Streaming",
+          name: dataFeedName,
+          protocol: protocol || "tls",
+          auth: authType || "X_509",
+          port: port ? parseInt(port, 10) : 8089,
+          coreVersion: coreVersion || "2",
+          coreVersion2TlsVersions: coreVersion2TlsVersions || "",
+          group: multicastGroup || "",
+          iface: iface || "",
+          syncCacheRetentionSeconds: syncCacheRetention ? String(syncCacheRetention) : "3600",
+          archive: archive === "true",
+          anongroup: anongroup === "true",
+          archiveOnly: archiveOnly === "true",
+          sync: sync === "true",
+          federated: federated === "true",
+          tag: payloadTags,
+          filtergroup: strippedGroups
+        };
+
+        const takClient = takSvc.buildTakAxios();
+        await takClient.post("/api/datafeeds", dataFeedPayload);
+
+        try {
+          if (result && result.user && result.user.pk) {
+            await users.updateUserAttributes(result.user.pk, { tak_data_feed_name: dataFeedName });
+          }
+        } catch (attrsErr) {
+           console.warn("Failed to securely hook data feed name into Authentik attributes:", attrsErr);
+        }
+      } catch (feedErr) {
+        dataFeedError = feedErr?.response?.data?.message || feedErr?.message || String(feedErr);
+      }
+    }
+
     const groupName =
       Array.isArray(result?.groups) && result.groups[0]
         ? result.groups[0].name
@@ -116,7 +160,7 @@ router.post("/", async (req, res) => {
       },
     });
 
-    res.json({ success: true, certBundleReady, certError, ...result });
+    res.json({ success: true, certBundleReady, certError, dataFeedError, ...result });
   } catch (err) {
     res.status(400).json({ error: toErrorPayload(err) });
   }
@@ -254,6 +298,99 @@ router.delete("/:userId", async (req, res) => {
     res.json({ success: true });
   } catch (err) {
     res.status(400).json({ error: toErrorPayload(err) });
+  }
+});
+
+/**
+ * GET /api/integrations/:username/datafeed
+ * Fetches the upstream TAK Server Data Feed payload for a matching integration.
+ */
+router.get("/:username/datafeed", async (req, res) => {
+  try {
+    const list = await users.findIntegrationUsers();
+    const user = list.find((u) => u.username === req.params.username);
+    if (!user) {
+      return res.status(404).json({ error: "Integration user not found." });
+    }
+
+    const dataFeedName = user.attributes?.tak_data_feed_name;
+    if (!dataFeedName) {
+      return res.status(404).json({ error: "No Data Feed is associated with this integration." });
+    }
+
+    if (!takSvc.isTakConfigured()) {
+      return res.status(503).json({ error: "TAK Server connection is not configured." });
+    }
+
+    const takClient = takSvc.buildTakAxios();
+    // TAK API: GET /api/datafeeds/{name}
+    const dfRes = await takClient.get(`/api/datafeeds/${encodeURIComponent(dataFeedName)}`);
+    const dataFeedPayload = dfRes.data?.data || dfRes.data;
+    
+    res.json({ dataFeed: dataFeedPayload });
+  } catch (err) {
+    res.status(500).json({ error: toErrorPayload(err) });
+  }
+});
+
+/**
+ * POST /api/integrations/:username/datafeed
+ * Creates a TAK Server Data Feed retroactively for an integration that doesn't have one.
+ */
+router.post("/:username/datafeed", async (req, res) => {
+  try {
+    const list = await users.findIntegrationUsers();
+    const user = list.find((u) => u.username === req.params.username);
+    if (!user) {
+      return res.status(404).json({ error: "Integration user not found." });
+    }
+
+    if (user.attributes?.tak_data_feed_name) {
+      return res.status(400).json({ error: "Integration already has an associated Data Feed." });
+    }
+
+    const { dataFeedName, protocol, authType, port, coreVersion, coreVersion2TlsVersions, multicastGroup, iface, syncCacheRetention, archive, anongroup, archiveOnly, sync, federated, tags, filterGroups } = req.body || {};
+
+    if (!dataFeedName) {
+      return res.status(400).json({ error: "Data Feed Name is required." });
+    }
+
+    if (!takSvc.isTakConfigured()) {
+      return res.status(503).json({ error: "TAK Server connection is not configured." });
+    }
+
+    const payloadTags = tags ? tags.split(/[\n,]+/).map(t => t.trim()).filter(Boolean) : [];
+    const strippedGroups = Array.isArray(filterGroups) ? filterGroups.map(stripTakPrefix) : [];
+    
+    const dataFeedPayload = {
+      type: "Streaming",
+      name: dataFeedName,
+      protocol: protocol || "tls",
+      auth: authType || "X_509",
+      port: port ? parseInt(port, 10) : 8089,
+      coreVersion: coreVersion || "2",
+      coreVersion2TlsVersions: coreVersion2TlsVersions || "",
+      group: multicastGroup || "",
+      iface: iface || "",
+      syncCacheRetentionSeconds: syncCacheRetention ? String(syncCacheRetention) : "3600",
+      archive: archive === "true",
+      anongroup: anongroup === "true",
+      archiveOnly: archiveOnly === "true",
+      sync: sync === "true",
+      federated: federated === "true",
+      tag: payloadTags,
+      filtergroup: strippedGroups
+    };
+
+    const takClient = takSvc.buildTakAxios();
+    await takClient.post("/api/datafeeds", dataFeedPayload);
+
+    await users.updateUserAttributes(user.pk, { tak_data_feed_name: dataFeedName });
+
+    res.json({ message: "Data Feed successfully created and bound to Integration." });
+  } catch (err) {
+    const upstreamError = err?.response?.data?.message || err?.message || String(err);
+    res.status(500).json({ error: "TAK Server Error: " + upstreamError });
   }
 });
 

--- a/routes/integrations.routes.js
+++ b/routes/integrations.routes.js
@@ -133,7 +133,11 @@ router.post("/", async (req, res) => {
            console.warn("Failed to securely hook data feed name into Authentik attributes:", attrsErr);
         }
       } catch (feedErr) {
-        dataFeedError = feedErr?.response?.data?.message || feedErr?.message || String(feedErr);
+        let det = null;
+        if (feedErr.response && feedErr.response.data) {
+           det = typeof feedErr.response.data === 'object' ? JSON.stringify(feedErr.response.data) : String(feedErr.response.data);
+        }
+        dataFeedError = (feedErr.message || "TAK API failed") + (det ? " | " + det : "");
       }
     }
 
@@ -329,7 +333,12 @@ router.get("/:username/datafeed", async (req, res) => {
     
     res.json({ dataFeed: dataFeedPayload });
   } catch (err) {
-    res.status(500).json({ error: toErrorPayload(err) });
+    console.error("Error pulling retroactive Data Feed properties:", err);
+    let msg = err.message || "Failed reading from upstream Data Feed API";
+    if (err.response && err.response.data) {
+       msg += " | " + (typeof err.response.data === 'object' ? JSON.stringify(err.response.data) : String(err.response.data));
+    }
+    return res.status(500).json({ error: msg });
   }
 });
 

--- a/services/users.service.js
+++ b/services/users.service.js
@@ -2222,6 +2222,16 @@ async function getUserById(userId) {
   return res.data;
 }
 
+// Update specific attributes on a user (merging with existing)
+async function updateUserAttributes(userId, changes) {
+  await assertUserNotActionLocked(userId, { ignoreLocks: true });
+  const user = await getUserById(userId);
+  const newAttrs = { ...(user.attributes || {}), ...changes };
+  await api.patch(`/core/users/${userId}/`, { attributes: JSON.stringify(newAttrs) });
+  invalidateUsersCache();
+  return newAttrs;
+}
+
 // Add groups to a user (merge)
 async function addUserGroups(userId, groupIds) {
   await assertUserNotActionLocked(userId);

--- a/services/users.service.js
+++ b/services/users.service.js
@@ -2227,7 +2227,7 @@ async function updateUserAttributes(userId, changes) {
   await assertUserNotActionLocked(userId, { ignoreLocks: true });
   const user = await getUserById(userId);
   const newAttrs = { ...(user.attributes || {}), ...changes };
-  await api.patch(`/core/users/${userId}/`, { attributes: JSON.stringify(newAttrs) });
+  await api.patch(`/core/users/${userId}/`, { attributes: newAttrs });
   invalidateUsersCache();
   return newAttrs;
 }

--- a/services/users.service.js
+++ b/services/users.service.js
@@ -2459,6 +2459,7 @@ module.exports = {
   updateEmail,
   updateName,
   setUserGroups,
+  updateUserAttributes,
   toggleUserActive,
   deleteUser,
   addUserGroups,

--- a/views/integrations.ejs
+++ b/views/integrations.ejs
@@ -129,8 +129,8 @@
           <h2 style="margin-top: 0; font-size: 1.1em; color: var(--text-muted);">Enter Data Feed Details</h2>
           
           <div class="row">
-            <label style="flex: 1; min-width: 200px;">*Name
-              <input type="text" name="dataFeedName" required style="width: 100%;" />
+            <label style="display: block; margin-bottom: 8px; font-weight: bold;">Data Feed Name
+              <input type="text" name="dataFeedName" disabled style="width: 100%; color: var(--text-2);" placeholder="(Auto-Generated to Match Integration)" />
             </label>
           </div>
           <div class="row" style="margin-top: 12px;">

--- a/views/integrations.ejs
+++ b/views/integrations.ejs
@@ -45,6 +45,13 @@
             <option value="">Select a group</option>
           </select>
         </label>
+        
+        <label style="min-width: 250px;">Make Streaming Data Feed?
+          <select name="makeDataFeed" id="makeDataFeed" style="min-width: 100px;">
+            <option value="yes">Yes</option>
+            <option value="no">No</option>
+          </select>
+        </label>
 
         <label>&nbsp;
           <button class="btn" type="submit">Create Integration</button>
@@ -70,6 +77,7 @@
         <tr>
           <th>Username</th>
           <th>Group</th>
+          <th>Data Feed</th>
           <th>Status</th>
           <th>Actions</th>
         </tr>
@@ -104,6 +112,129 @@
           <span id="editIntegrationMsg" class="msg"></span>
         </div>
       </div>
+    </div>
+</div>
+</div>
+
+<!-- Data Feed Modal -->
+<div class="modalOverlay" id="dataFeedModalOverlay" style="display: none;">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="dataFeedTitle">
+    <div class="modalHeader">
+      <h2 id="dataFeedTitle" style="margin: 0;">Create Streaming Data Feed</h2>
+      <button class="btn" id="dataFeedCloseBtn" type="button">Close</button>
+    </div>
+    <div class="modalBody">
+      <form id="dataFeedForm" autocomplete="off" style="margin: 0;">
+        <div class="card" style="margin: 0;">
+          <h2 style="margin-top: 0; font-size: 1.1em; color: var(--text-muted);">Enter Data Feed Details</h2>
+          
+          <div class="row">
+            <label style="flex: 1; min-width: 200px;">*Name
+              <input type="text" name="dataFeedName" required style="width: 100%;" />
+            </label>
+          </div>
+          <div class="row" style="margin-top: 12px;">
+            <label style="flex: 1; min-width: 200px;">Tags
+              <textarea name="tags" rows="2" style="width: 100%; resize: vertical;" placeholder="Provide 0 or more tags separated by newlines. Example:&#10;red&#10;green"></textarea>
+            </label>
+          </div>
+          <div class="row" style="margin-top: 12px;">
+            <label style="flex: 1; min-width: 200px;">*Protocol
+              <select name="protocol" style="width: 100%;" required>
+                <option value="tls" selected>Secure Streaming TCP (TLS) CoT or Protobuf</option>
+                <option value="tcp">Streaming TCP CoT or Protobuf</option>
+                <option value="stcp">Streaming TCP (Legacy)</option>
+              </select>
+            </label>
+            <label style="flex: 1; min-width: 140px;">*Authentication Type
+              <select name="authType" style="width: 100%;" required>
+                <option value="X_509" selected>X.509</option>
+                <option value="ANONYMOUS">Anonymous</option>
+                <option value="BEARER">Bearer</option>
+              </select>
+            </label>
+          </div>
+          <div class="row" style="margin-top: 12px;">
+             <label style="flex: 1; min-width: 200px;">*Port
+              <input type="number" name="port" required style="width: 100%;" placeholder="e.g. 8089" min="1" max="65535" />
+            </label>
+            <label style="flex: 1; min-width: 200px;">Core Messaging Version
+              <select name="coreVersion" style="width: 100%;">
+                <option value="2" selected>2 (high performance)</option>
+                <option value="1">1</option>
+              </select>
+              <div style="font-size: 0.85em; margin-top: 6px; display: flex; gap: 10px; align-items: center;">
+                <span>TLS Versions:</span>
+                <label style="font-weight: normal; margin: 0;"><input type="checkbox" name="tlsv1" /> TLSv1</label>
+                <label style="font-weight: normal; margin: 0;"><input type="checkbox" name="tlsv1_1" /> TLSv1.1</label>
+                <label style="font-weight: normal; margin: 0;"><input type="checkbox" name="tlsv1_2" checked /> TLSv1.2</label>
+                <label style="font-weight: normal; margin: 0;"><input type="checkbox" name="tlsv1_3" checked /> TLSv1.3</label>
+              </div>
+            </label>
+          </div>
+          <div class="row" style="margin-top: 12px;">
+            <label style="flex: 1; min-width: 200px;">Multicast Group
+              <input type="text" name="multicastGroup" style="width: 100%;" />
+            </label>
+            <label style="flex: 1; min-width: 140px;">Interface
+              <input type="text" name="interface" style="width: 100%;" />
+            </label>
+          </div>
+          
+          <div class="row" style="margin-top: 12px;">
+             <label style="flex: 1; min-width: 200px;">Sync Cache Retention
+              <input type="number" name="syncCacheRetention" value="3600" style="width: 100%;" />
+            </label>
+             <label style="flex: 1; min-width: 140px;">Archive
+              <select name="archive" style="width: 100%;">
+                <option value="true" selected>True</option>
+                <option value="false">False</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="row" style="margin-top: 12px;">
+             <label style="flex: 1; min-width: 200px;">Anonymous Group
+              <select name="anongroup" style="width: 100%;">
+                <option value="true">True</option>
+                <option value="false" selected>False</option>
+              </select>
+            </label>
+             <label style="flex: 1; min-width: 140px;">Archive Only
+              <select name="archiveOnly" style="width: 100%;">
+                <option value="true">True</option>
+                <option value="false" selected>False</option>
+              </select>
+            </label>
+          </div>
+
+          <div style="margin-top: 16px;">
+            <label style="display: block; margin-bottom: 8px; font-weight: bold;">Filter Groups</label>
+            <div id="filterGroupsCheckboxList" style="max-height: 150px; overflow-y: auto; border: 1px solid var(--border-color); border-radius: 4px; padding: 8px;">
+              <!-- Checkboxes populate here -->
+            </div>
+          </div>
+          
+           <div class="row" style="margin-top: 12px;">
+             <label style="flex: 1; min-width: 200px;">Sync
+              <select name="sync" style="width: 100%;">
+                <option value="true">True</option>
+                <option value="false" selected>False</option>
+              </select>
+            </label>
+             <label style="flex: 1; min-width: 140px;">Federated
+              <select name="federated" style="width: 100%;">
+                <option value="true" selected>True</option>
+                <option value="false">False</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="row" style="margin-top: 16px; align-items: center;">
+            <button class="btn success" type="submit">Submit & Create Integration</button>
+          </div>
+        </div>
+      </form>
     </div>
   </div>
 </div>
@@ -261,9 +392,18 @@
         var statusPill = isConnected
           ? "<span class=\"status-pill status-connected\">Connected</span>"
           : "<span class=\"status-pill status-disconnected\">Disconnected</span>";
+
+        var dataFeedButtonHtml;
+        if (u.dataFeedName) {
+          dataFeedButtonHtml = "<button class=\"btn success\" type=\"button\" data-action=\"data-feed\" data-mode=\"view\" data-username=\"" + esc(u.username) + "\">DF Enabled</button>";
+        } else {
+          dataFeedButtonHtml = "<button class=\"btn danger\" type=\"button\" data-action=\"data-feed\" data-mode=\"create\" data-username=\"" + esc(u.username) + "\" data-grouppk=\"" + esc(currentGroupPk) + "\" data-title=\"" + esc(u.name || "") + "\">No DF</button>";
+        }
+
         return "<tr>" +
           "<td>" + esc(u.username) + "</td>" +
           "<td>" + esc(groupDisplay) + "</td>" +
+          "<td>" + dataFeedButtonHtml + "</td>" +
           "<td>" + statusPill + "</td>" +
           "<td><div class=\"row\" style=\"gap:8px; flex-wrap:wrap;\">" +
           "<button class=\"btn success\" type=\"button\" data-action=\"download-certs\" data-pk=\"" + esc(u.pk) + "\" data-username=\"" + esc(u.username) + "\">Download Certs</button>" +
@@ -356,6 +496,87 @@
         var username = btn.getAttribute("data-username");
         var groupPk = btn.getAttribute("data-group");
         openEditModal(pk, username, groupPk);
+      });
+    });
+    tbody.querySelectorAll("button[data-action=\"data-feed\"]").forEach(function (btn) {
+      btn.addEventListener("click", async function () {
+        const username = btn.getAttribute("data-username");
+        const mode = btn.getAttribute("data-mode");
+        const title = btn.getAttribute("data-title");
+        const groupPk = btn.getAttribute("data-grouppk");
+        
+        if (mode === "create") {
+            integrationRetroactiveUsername = username;
+            filterGroupsCheckboxList.innerHTML = groupsCache.map(function(g) {
+               const isChecked = (g.pk === groupPk) ? "checked" : "";
+               const displayName = stripTakPrefix(g.name) || g.pk;
+               return `<label style="display: flex; flex-direction: row; align-items: center; font-weight: normal; margin-bottom: 6px; width: 100%;">
+                         <input type="checkbox" value="${esc(g.name)}" style="margin-right: 8px; margin-top: 0;" ${isChecked} />
+                         ${esc(displayName)}
+                       </label>`;
+            }).join("");
+            
+            dataFeedForm.reset();
+            Array.from(dataFeedForm.elements).forEach(el => el.disabled = false);
+            document.getElementById("dataFeedSubmitBtn").style.display = "block";
+            dataFeedForm.dataFeedName.value = title || "";
+            dataFeedModalOverlay.style.display = "flex";
+            
+        } else if (mode === "view") {
+            try {
+              btn.disabled = true;
+              setTableMsg("Fetching mapped Data Feed for " + username + "...");
+              const res = await fetch(`/api/integrations/${encodeURIComponent(username)}/datafeed`);
+              const feed = await res.json();
+              if (res.ok && feed.dataFeed) {
+                 const f = feed.dataFeed;
+                 
+                 dataFeedForm.reset();
+                 document.getElementById("dataFeedSubmitBtn").style.display = "none";
+                 
+                 dataFeedForm.dataFeedName.value = f.name || "";
+                 dataFeedForm.tags.value = (f.tag || []).join("\n");
+                 dataFeedForm.protocol.value = f.protocol || "tls";
+                 dataFeedForm.authType.value = f.auth || "X_509";
+                 dataFeedForm.port.value = f.port || 8089;
+                 dataFeedForm.coreVersion.value = f.coreVersion || "2";
+
+                 const tls = String(f.coreVersion2TlsVersions || "").split(",");
+                 dataFeedForm.tlsv1.checked = tls.includes("TLSv1");
+                 dataFeedForm.tlsv1_1.checked = tls.includes("TLSv1.1");
+                 dataFeedForm.tlsv1_2.checked = tls.includes("TLSv1.2");
+                 dataFeedForm.tlsv1_3.checked = tls.includes("TLSv1.3");
+
+                 dataFeedForm.multicastGroup.value = f.group || "";
+                 dataFeedForm.interface.value = f.iface || "";
+                 dataFeedForm.syncCacheRetention.value = f.syncCacheRetentionSeconds || "3600";
+                 dataFeedForm.archive.value = f.archive === true ? "true" : "false";
+                 dataFeedForm.anongroup.value = f.anongroup === true ? "true" : "false";
+                 dataFeedForm.archiveOnly.value = f.archiveOnly === true ? "true" : "false";
+                 dataFeedForm.sync.value = f.sync === true ? "true" : "false";
+                 dataFeedForm.federated.value = f.federated === true ? "true" : "false";
+
+                 filterGroupsCheckboxList.innerHTML = ((f.filtergroup || [])).map(function(grp) {
+                     const displayName = stripTakPrefix(grp);
+                     return `<label style="display: flex; flex-direction: row; align-items: center; font-weight: normal; margin-bottom: 6px; width: 100%;">
+                               <input type="checkbox" checked disabled style="margin-right: 8px; margin-top: 0;"/>
+                               ${esc(displayName)}
+                             </label>`;
+                 }).join("");
+                 
+                 Array.from(dataFeedForm.elements).forEach(el => el.disabled = true);
+                 document.getElementById("dataFeedCloseBtn").disabled = false;
+                 dataFeedModalOverlay.style.display = "flex";
+                 setTableMsg("");
+              } else {
+                 setTableMsg("Could not load Data Feed.", false);
+              }
+            } catch (err) {
+              setTableMsg("Failed fetching external Data Feed metadata", false);
+            } finally {
+              btn.disabled = false;
+            }
+        }
       });
     });
     tbody.querySelectorAll("button[data-action=\"download-certs\"]").forEach(function (btn) {
@@ -461,6 +682,138 @@
     if (type === "agency") payload.agencySuffix = agencySelect.value;
     if (type === "county") payload.county = countySelect.value;
     if (type === "state") payload.state = stateSelect.value;
+
+    const mkFeeds = document.getElementById("makeDataFeed");
+    const isSkipDataFeed = mkFeeds && mkFeeds.value === "no";
+    
+    if (isSkipDataFeed) {
+       payload.skipDataFeed = true;
+       submitIntegration(payload);
+       return;
+    }
+
+    integrationPayloadCache = payload;
+    integrationRetroactiveUsername = null;
+    
+    // Render Filter Groups checkboxes for standard flow
+    filterGroupsCheckboxList.innerHTML = groupsCache.map(function(g) {
+        const isChecked = (g.pk === groupId) ? "checked" : "";
+        const displayName = stripTakPrefix(g.name) || g.pk;
+        return `<label style="display: flex; flex-direction: row; align-items: center; font-weight: normal; margin-bottom: 6px; width: 100%;">
+                  <input type="checkbox" value="${esc(g.name)}" style="margin-right: 8px; margin-top: 0;" ${isChecked} />
+                  ${esc(displayName)}
+                </label>`;
+    }).join("");
+
+    dataFeedForm.reset();
+    Array.from(dataFeedForm.elements).forEach(el => el.disabled = false);
+    document.getElementById("dataFeedSubmitBtn").style.display = "block";
+    dataFeedForm.dataFeedName.value = title;
+    
+    dataFeedModalOverlay.style.display = "flex";
+  });
+
+  let integrationPayloadCache = null;
+  let integrationRetroactiveUsername = null;
+  const dataFeedModalOverlay = document.getElementById("dataFeedModalOverlay");
+  const dataFeedCloseBtn = document.getElementById("dataFeedCloseBtn");
+  const dataFeedForm = document.getElementById("dataFeedForm");
+  const filterGroupsCheckboxList = document.getElementById("filterGroupsCheckboxList");
+
+  if (dataFeedCloseBtn) {
+    dataFeedCloseBtn.addEventListener("click", function() {
+      dataFeedModalOverlay.style.display = "none";
+      integrationPayloadCache = null;
+      integrationRetroactiveUsername = null;
+    });
+  }
+
+  dataFeedForm.addEventListener("submit", async function(e) {
+    e.preventDefault();
+    if (!integrationPayloadCache) return;
+
+    const payload = integrationPayloadCache;
+    
+    payload.dataFeedName = dataFeedForm.dataFeedName.value.trim();
+    payload.tags = dataFeedForm.tags.value;
+    payload.protocol = dataFeedForm.protocol.value;
+    payload.authType = dataFeedForm.authType.value;
+    payload.port = dataFeedForm.port.value;
+    payload.coreVersion = dataFeedForm.coreVersion.value;
+    
+    const tlsVersions = [];
+    if (dataFeedForm.tlsv1.checked) tlsVersions.push("TLSv1");
+    if (dataFeedForm.tlsv1_1.checked) tlsVersions.push("TLSv1.1");
+    if (dataFeedForm.tlsv1_2.checked) tlsVersions.push("TLSv1.2");
+    if (dataFeedForm.tlsv1_3.checked) tlsVersions.push("TLSv1.3");
+    payload.coreVersion2TlsVersions = tlsVersions.join(",");
+
+    payload.multicastGroup = dataFeedForm.multicastGroup.value.trim();
+    payload.iface = dataFeedForm.interface.value.trim();
+    payload.syncCacheRetention = dataFeedForm.syncCacheRetention.value;
+    payload.archive = dataFeedForm.archive.value;
+    payload.anongroup = dataFeedForm.anongroup.value;
+    payload.archiveOnly = dataFeedForm.archiveOnly.value;
+    payload.sync = dataFeedForm.sync.value;
+    payload.federated = dataFeedForm.federated.value;
+
+    const checkedBoxes = filterGroupsCheckboxList.querySelectorAll('input[type="checkbox"]:checked');
+    const filterGroups = [];
+    checkedBoxes.forEach(function(box) {
+        filterGroups.push(box.value);
+    });
+    
+    const dataFeedPayloadSegment = {
+      dataFeedName: dataFeedForm.dataFeedName.value.trim(),
+      tags: dataFeedForm.tags.value,
+      protocol: dataFeedForm.protocol.value,
+      authType: dataFeedForm.authType.value,
+      port: dataFeedForm.port.value,
+      coreVersion: dataFeedForm.coreVersion.value,
+      coreVersion2TlsVersions: tlsVersions.join(","),
+      multicastGroup: dataFeedForm.multicastGroup.value.trim(),
+      iface: dataFeedForm.interface.value.trim(),
+      syncCacheRetention: dataFeedForm.syncCacheRetention.value,
+      archive: dataFeedForm.archive.value,
+      anongroup: dataFeedForm.anongroup.value,
+      archiveOnly: dataFeedForm.archiveOnly.value,
+      sync: dataFeedForm.sync.value,
+      federated: dataFeedForm.federated.value,
+      filterGroups: filterGroups
+    };
+
+    dataFeedModalOverlay.style.display = "none";
+
+    // Handle Retroactive Data Feed mode
+    if (integrationRetroactiveUsername) {
+       setTableMsg("Generating Data Feed for " + integrationRetroactiveUsername + "...", false);
+       try {
+         const res = await fetch(`/api/integrations/${encodeURIComponent(integrationRetroactiveUsername)}/datafeed`, {
+           method: "POST",
+           headers: { "Content-Type": "application/json" },
+           body: JSON.stringify(dataFeedPayloadSegment)
+         });
+         const out = await res.json();
+         if (!res.ok) {
+           setTableMsg(out.error || "Retroactive Data Feed creation failed", false);
+         } else {
+           setTableMsg("Successfully created and mapped Data Feed.", true);
+           loadIntegrations();
+         }
+       } catch (err) {
+         setTableMsg(err.message || "Request failed", false);
+       }
+       integrationRetroactiveUsername = null;
+       return;
+    }
+
+    // Default Creation Flow
+    Object.assign(payload, dataFeedPayloadSegment);
+    submitIntegration(payload);
+  });
+
+  async function submitIntegration(payload) {
+    setCreateMsg("Creating integration...", true);
     try {
       const res = await fetch("/api/integrations", {
         method: "POST",
@@ -473,11 +826,21 @@
         return;
       }
       const username = (out.user && out.user.username) || "";
+      
+      let msgStr = "Integration \"" + username + "\" created successfully.";
       if (out.certError) {
-        setCreateMsg("Integration \"" + username + "\" created, but cert automation failed: " + out.certError, false);
-      } else {
-        setCreateMsg("Integration \"" + username + "\" created successfully. Downloading cert bundle...", true);
+        msgStr += " Cert automation failed: " + out.certError + ".";
       }
+      if (out.dataFeedError) {
+        msgStr += " Data feed creation failed: " + out.dataFeedError + ".";
+      }
+
+      if (out.certError || out.dataFeedError) {
+        setCreateMsg(msgStr, false);
+      } else {
+        setCreateMsg(msgStr + " Downloading cert bundle...", true);
+      }
+      
       createForm.reset();
       groupSelect.value = "";
       integrationType.value = "global";
@@ -494,7 +857,7 @@
     } catch (err) {
       setCreateMsg(err.message || "Create failed", false);
     }
-  });
+  }
 
   (async function init() {
     try {

--- a/views/integrations.ejs
+++ b/views/integrations.ejs
@@ -518,6 +518,7 @@
             }).join("");
             
             dataFeedForm.reset();
+            document.getElementById("dataFeedTitle").innerText = "Create Streaming Data Feed";
             Array.from(dataFeedForm.elements).forEach(el => {
                 if (el.name !== "dataFeedName") el.disabled = false;
             });
@@ -535,6 +536,7 @@
                  const f = feed.dataFeed;
                  
                  dataFeedForm.reset();
+                 document.getElementById("dataFeedTitle").innerText = "Data Feed Details";
                  document.getElementById("dataFeedSubmitBtn").style.display = "none";
                  
                  dataFeedForm.dataFeedName.value = f.name || "";
@@ -709,6 +711,7 @@
     }).join("");
 
     dataFeedForm.reset();
+    document.getElementById("dataFeedTitle").innerText = "Create Streaming Data Feed";
     Array.from(dataFeedForm.elements).forEach(el => {
         if (el.name !== "dataFeedName") el.disabled = false;
     });

--- a/views/integrations.ejs
+++ b/views/integrations.ejs
@@ -157,6 +157,7 @@
           <div class="row" style="margin-top: 12px;">
              <label style="flex: 1; min-width: 200px;">*Port
               <input type="number" name="port" required style="width: 100%;" placeholder="e.g. 8089" min="1" max="65535" />
+              <small style="display: block; color: var(--text-2); font-size: 0.85em; margin-top: 4px;">Note: Ensure this port is opened in your firewall prior to establishing a data connection.</small>
             </label>
             <label style="flex: 1; min-width: 200px;">Core Messaging Version
               <select name="coreVersion" style="width: 100%;">

--- a/views/integrations.ejs
+++ b/views/integrations.ejs
@@ -231,7 +231,7 @@
           </div>
 
           <div class="row" style="margin-top: 16px; align-items: center;">
-            <button class="btn success" type="submit">Submit & Create Integration</button>
+            <button id="dataFeedSubmitBtn" class="btn success" type="submit">Submit & Create Integration</button>
           </div>
         </div>
       </form>

--- a/views/integrations.ejs
+++ b/views/integrations.ejs
@@ -518,9 +518,11 @@
             }).join("");
             
             dataFeedForm.reset();
-            Array.from(dataFeedForm.elements).forEach(el => el.disabled = false);
+            Array.from(dataFeedForm.elements).forEach(el => {
+                if (el.name !== "dataFeedName") el.disabled = false;
+            });
             document.getElementById("dataFeedSubmitBtn").style.display = "block";
-            dataFeedForm.dataFeedName.value = title || "";
+            dataFeedForm.dataFeedName.value = "";
             dataFeedModalOverlay.style.display = "flex";
             
         } else if (mode === "view") {
@@ -707,9 +709,11 @@
     }).join("");
 
     dataFeedForm.reset();
-    Array.from(dataFeedForm.elements).forEach(el => el.disabled = false);
+    Array.from(dataFeedForm.elements).forEach(el => {
+        if (el.name !== "dataFeedName") el.disabled = false;
+    });
     document.getElementById("dataFeedSubmitBtn").style.display = "block";
-    dataFeedForm.dataFeedName.value = title;
+    dataFeedForm.dataFeedName.value = "";
     
     dataFeedModalOverlay.style.display = "flex";
   });

--- a/views/integrations.ejs
+++ b/views/integrations.ejs
@@ -187,8 +187,8 @@
             </label>
              <label style="flex: 1; min-width: 140px;">Archive
               <select name="archive" style="width: 100%;">
-                <option value="true" selected>True</option>
-                <option value="false">False</option>
+                <option value="true">True</option>
+                <option value="false" selected>False</option>
               </select>
             </label>
           </div>


### PR DESCRIPTION
When an administrator creates a new Integration user, they frequently need a streaming data feed bound to that integration. This modification introduces an intermediate modal structure that captures streaming data feed metrics. It additionally grants administrators the choice to skip the prompt, decouple the creation process, and visually observe mapped Integrations directly in the portal dashboard via new Red/Green table toggles.
[TAK-Portal_Streaming_DataFeed_Handoff.md](https://github.com/user-attachments/files/26580926/TAK-Portal_Streaming_DataFeed_Handoff.md)
