### PR TITLE
Add bridge member groups for CloudTAK locate API access.

### DIFF
--- a/routes/locate.routes.js
+++ b/routes/locate.routes.js
@@ -9,8 +9,36 @@ const auditSvc = require("../services/auditLog.service");
 const { renderTemplate, htmlToText } = require("../services/emailTemplates.service");
 const { toSafeApiError } = require("../services/apiErrorPayload.service");
 const smsSvc = require("../services/sms.service");
+const settingsSvc = require("../services/settings.service");
+const { getString } = require("../services/env");
 
 const EMAIL_RE = /^\S+@\S+\.[A-Za-z]{2,}$/;
+
+/** Public share URL for /locate/:slug — prefers TAK_PORTAL_PUBLIC_URL (required for CloudTAK bridge). */
+function buildPublicLocateUrl(req, slug) {
+  let base = "";
+  try {
+    const settings = settingsSvc.getSettings ? settingsSvc.getSettings() || {} : {};
+    if (settings.TAK_PORTAL_PUBLIC_URL && String(settings.TAK_PORTAL_PUBLIC_URL).trim()) {
+      base = String(settings.TAK_PORTAL_PUBLIC_URL).trim().replace(/\/+$/, "");
+    }
+  } catch (_) {
+    /* ignore */
+  }
+  if (!base) {
+    const env = getString("TAK_PORTAL_PUBLIC_URL", "").trim().replace(/\/+$/, "");
+    if (env) base = env;
+  }
+  if (base) {
+    return `${base}/locate/${encodeURIComponent(slug)}`;
+  }
+  const proto =
+    String(req.get("x-forwarded-proto") || req.protocol || "https")
+      .split(",")[0]
+      .trim() || "https";
+  const host = String(req.get("x-forwarded-host") || req.get("host") || "").trim();
+  return `${proto}://${host}/locate/${encodeURIComponent(slug)}`;
+}
 
 function auditRequest(req) {
   return {
@@ -560,11 +588,7 @@ router.post("/locators/:id/send-link-email", async (req, res) => {
       });
     }
 
-    const proto = String(req.get("x-forwarded-proto") || req.protocol || "https")
-      .split(",")[0]
-      .trim() || "https";
-    const host = req.get("host") || "";
-    const url = `${proto}://${host}/locate/${encodeURIComponent(loc.slug)}`;
+    const url = buildPublicLocateUrl(req, loc.slug);
 
     const subject = "Share your location";
     const message = `Please open this link on your phone to share your location with responders:\n\n${url}\n`;
@@ -641,11 +665,7 @@ router.post("/locators/:id/send-link-sms", async (req, res) => {
       });
     }
 
-    const proto = String(req.get("x-forwarded-proto") || req.protocol || "https")
-      .split(",")[0]
-      .trim() || "https";
-    const host = req.get("host") || "";
-    const url = `${proto}://${host}/locate/${encodeURIComponent(loc.slug)}`;
+    const url = buildPublicLocateUrl(req, loc.slug);
     const text = `Please open this link on your phone to share your location with responders:\n\n${url}`;
 
     for (const phone of parsed.phones) {

--- a/services/permissions.service.js
+++ b/services/permissions.service.js
@@ -5,6 +5,7 @@
 const fs = require("fs");
 const path = require("path");
 const registry = require("./permissions.registry");
+const { getString } = require("./env");
 
 const DATA_FILE = path.join(__dirname, "..", "data", "permission-overrides.json");
 
@@ -51,6 +52,14 @@ function getRoleType(user) {
  * @param {boolean} authDisabled - PORTAL_AUTH_ENABLED false: full access
  * @returns {Set<string>}
  */
+function getBridgeMemberPermissions() {
+  const permsRaw = getString("PORTAL_BRIDGE_MEMBER_PERMISSIONS", "page.locate");
+  return String(permsRaw || "")
+    .split(",")
+    .map((p) => p.trim())
+    .filter((id) => registry.isValidPermissionId(id));
+}
+
 function getEffectivePermissionSet(user, authDisabled) {
   if (authDisabled) {
     return new Set(registry.ALL_PERMISSION_IDS);
@@ -60,10 +69,17 @@ function getEffectivePermissionSet(user, authDisabled) {
   const un = normalizeUsername(user && user.username);
   const all = loadOverridesFromDisk();
   const entry = un && all[un] ? all[un] : null;
-  if (!entry) {
-    return new Set(base);
-  }
   const out = new Set(base);
+
+  if (user && user.isBridgeMember) {
+    for (const id of getBridgeMemberPermissions()) {
+      out.add(id);
+    }
+  }
+
+  if (!entry) {
+    return out;
+  }
   const allow = Array.isArray(entry.allow) ? entry.allow : [];
   for (const id of allow) {
     if (registry.isValidPermissionId(id)) {

--- a/services/portalAuth.middleware.js
+++ b/services/portalAuth.middleware.js
@@ -164,12 +164,20 @@ function portalAuthMiddleware(req, res, next) {
   const isAgencyAdmin =
     Array.isArray(agencySuffixesForUser) && agencySuffixesForUser.length > 0;
 
+  // CloudTAK (or other internal) bridge may inject member groups via X-Authentik-Groups
+  // without granting global/agency admin. See PORTAL_BRIDGE_MEMBER_GROUPS.
+  const bridgeMemberGroupsStr = getString("PORTAL_BRIDGE_MEMBER_GROUPS", "").trim();
+  const bridgeMemberGroups = parseGroupList(bridgeMemberGroupsStr);
+  const isBridgeMember =
+    bridgeMemberGroups.length > 0 &&
+    bridgeMemberGroups.some((needed) => userGroupsLower.includes(needed));
+
   const anyAdminGroupConfigured =
     globalGroups.length > 0 || accessSvc.hasAnyAgencyAdminsConfigured();
 
   // If no admin groups are configured at all, any authenticated user is allowed.
   const hasAnyRequired =
-    !anyAdminGroupConfigured || isGlobalAdmin || isAgencyAdmin;
+    !anyAdminGroupConfigured || isGlobalAdmin || isAgencyAdmin || isBridgeMember;
 
   function deny() {
     if (normalizedPath.startsWith("/api/")) {
@@ -195,7 +203,7 @@ function portalAuthMiddleware(req, res, next) {
 
     // —— Capability / path table (replaces per-role allowlists) ——
     const eff = permsSvc.getEffectivePermissionSet(
-      { username, isGlobalAdmin, isAgencyAdmin },
+      { username, isGlobalAdmin, isAgencyAdmin, isBridgeMember },
       false
     );
     if (!permsSvc.canAccessPath(eff, normalizedPath, method)) {
@@ -215,6 +223,7 @@ function portalAuthMiddleware(req, res, next) {
     groups: userGroups,
     isGlobalAdmin,
     isAgencyAdmin,
+    isBridgeMember,
     allowedAgencySuffixes: agencySuffixesForUser || [],
   };
 


### PR DESCRIPTION
PORTAL_BRIDGE_MEMBER_GROUPS lets internal bridge callers pass portal auth with locate-only permissions (page.locate) instead of global admin.