### PR TITLE
Block disabled users from self-service device access

### DIFF
--- a/routes/setupDevice.routes.js
+++ b/routes/setupDevice.routes.js
@@ -17,9 +17,23 @@ function requireLoggedIn(req, res) {
   return u;
 }
 
+async function requireActiveLoggedIn(req, res) {
+  const user = requireLoggedIn(req, res);
+  if (!user) return null;
+
+  const localUser = await usersSvc
+    .getUserById(user.uid || user.username)
+    .catch(() => null);
+  if (!localUser || localUser.is_active === false) {
+    res.status(403).json({ ok: false, error: "Account is disabled" });
+    return null;
+  }
+  return user;
+}
+
 router.post("/enroll-qr", async (req, res) => {
   try {
-    const user = requireLoggedIn(req, res);
+    const user = await requireActiveLoggedIn(req, res);
     if (!user) return;
 
     const takUrl = qrSvc.getTakUrl();
@@ -118,7 +132,7 @@ router.post("/enroll-qr", async (req, res) => {
 // GET preference data + QR for Android Step 3 (Configure Device Preferences)
 router.get("/preference-data", async (req, res) => {
   try {
-    const user = requireLoggedIn(req, res);
+    const user = await requireActiveLoggedIn(req, res);
     if (!user) return;
 
     const uid = String(user.uid || "").trim();
@@ -161,7 +175,7 @@ router.get("/preference-data", async (req, res) => {
 
 router.get("/data-package", async (req, res) => {
   try {
-    const user = requireLoggedIn(req, res);
+    const user = await requireActiveLoggedIn(req, res);
     if (!user) return;
 
     if (!enrollmentPkg.isDataPackageAvailable()) {
@@ -221,4 +235,5 @@ router.get("/data-package", async (req, res) => {
   }
 });
 
+router.requireActiveLoggedIn = requireActiveLoggedIn;
 module.exports = router;

--- a/routes/setupDevice.routes.js
+++ b/routes/setupDevice.routes.js
@@ -21,9 +21,7 @@ async function requireActiveLoggedIn(req, res) {
   const user = requireLoggedIn(req, res);
   if (!user) return null;
 
-  const localUser = await usersSvc
-    .getUserById(user.uid || user.username)
-    .catch(() => null);
+  const localUser = await usersSvc.getUserById(user.uid || user.username);
   if (!localUser || localUser.is_active === false) {
     res.status(403).json({ ok: false, error: "Account is disabled" });
     return null;

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -45,6 +45,7 @@ const TEST_FILES = [
   "mouStore.ensure.test.js",
   "directoryPkText.test.js",
   "backup.test.js",
+  "setupDeviceAccess.test.js",
 ];
 
 const testsDir = path.join(__dirname, "..", "tests");

--- a/tests/setupDeviceAccess.test.js
+++ b/tests/setupDeviceAccess.test.js
@@ -1,0 +1,42 @@
+const assert = require("assert");
+const router = require("../routes/setupDevice.routes");
+const usersSvc = require("../services/users.service");
+
+usersSvc.getUserById = async (id) => ({
+  username: String(id),
+  is_active: id !== "disabled",
+});
+
+function response() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.body = body; return this; },
+  };
+}
+
+(async () => {
+  assert.strictEqual(typeof router.requireActiveLoggedIn, "function");
+
+  const activeReq = { authentikUser: { uid: "active", username: "active" } };
+  const activeRes = response();
+  const active = await router.requireActiveLoggedIn(activeReq, activeRes);
+  assert.strictEqual(active.username, "active");
+  assert.strictEqual(activeRes.statusCode, 200);
+
+  const disabledReq = { authentikUser: { uid: "disabled", username: "disabled" } };
+  const disabledRes = response();
+  const disabled = await router.requireActiveLoggedIn(disabledReq, disabledRes);
+  assert.strictEqual(disabled, null);
+  assert.strictEqual(disabledRes.statusCode, 403);
+  assert.deepStrictEqual(disabledRes.body, {
+    ok: false,
+    error: "Account is disabled",
+  });
+
+  console.log("setupDeviceAccess tests passed");
+})().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/tests/setupDeviceAccess.test.js
+++ b/tests/setupDeviceAccess.test.js
@@ -2,10 +2,11 @@ const assert = require("assert");
 const router = require("../routes/setupDevice.routes");
 const usersSvc = require("../services/users.service");
 
-usersSvc.getUserById = async (id) => ({
-  username: String(id),
-  is_active: id !== "disabled",
-});
+usersSvc.getUserById = async (id) => {
+  if (id === "missing") return null;
+  if (id === "error") throw new Error("directory unavailable");
+  return { username: String(id), is_active: id !== "disabled" };
+};
 
 function response() {
   return {
@@ -34,6 +35,24 @@ function response() {
     ok: false,
     error: "Account is disabled",
   });
+
+  const missingReq = { authentikUser: { uid: "missing", username: "missing" } };
+  const missingRes = response();
+  const missing = await router.requireActiveLoggedIn(missingReq, missingRes);
+  assert.strictEqual(missing, null);
+  assert.strictEqual(missingRes.statusCode, 403);
+  assert.deepStrictEqual(missingRes.body, {
+    ok: false,
+    error: "Account is disabled",
+  });
+
+  const errorReq = { authentikUser: { uid: "error", username: "error" } };
+  const errorRes = response();
+  await assert.rejects(
+    () => router.requireActiveLoggedIn(errorReq, errorRes),
+    /directory unavailable/
+  );
+  assert.strictEqual(errorRes.statusCode, 200);
 
   console.log("setupDeviceAccess tests passed");
 })().catch((err) => {


### PR DESCRIPTION
Closes #51

A disabled Portal user could continue requesting self-service enrollment credentials from an already-authenticated Portal session. Fresh login and the active TAK stream were blocked, but `/api/setup-my-device/enroll-qr` only checked for an authenticated username and did not recheck the local directory `is_active` state.

This PR adds one active-user guard to self-service enrollment, preference data, and data-package routes. Disabled or missing local users receive `403 Account is disabled`; active users retain the existing flow.

Validation:

- RED test against unchanged code: missing `requireActiveLoggedIn` guard.
- GREEN regression test covering active and disabled users.
- Full clean-main `node scripts/run-tests.js` passes.
- No secrets or runtime artifacts included.
